### PR TITLE
Replay and migrate

### DIFF
--- a/src/process/interfaces/process.ts
+++ b/src/process/interfaces/process.ts
@@ -11,7 +11,7 @@ export interface InstantiateEvent {
   id: string;
   timestamp: Date;
   scenario: string;
-  actors: Record<string, Omit<Actor, 'title'>>;
+  actors: Record<string, Actor>;
   vars: Record<string, any>;
   result: any;
   hash: string;
@@ -82,4 +82,4 @@ export interface Process {
 
 export type PredictedState = Omit<State, 'timestamp' | 'notify'>;
 
-export type HashFn = <T extends Event = Event>(event: Omit<T, 'hash'>) => T;
+export type HashFn = <T extends Event>(event: Omit<T, 'hash'>) => T;

--- a/src/process/predict.ts
+++ b/src/process/predict.ts
@@ -47,7 +47,7 @@ function tryToStep<T extends Process>(process: T, options: { ajv?: Ajv; hashFn?:
 
   // No transitions, try timeout
   if (transitions.length === 0) {
-    return timeout(process, { ...options, force: true });
+    return timeout(process, { ...options, timePassed: Number.MAX_SAFE_INTEGER });
   }
 
   const tried = new Set<string>();

--- a/src/process/replay.ts
+++ b/src/process/replay.ts
@@ -1,0 +1,162 @@
+import Ajv from 'ajv/dist/2020';
+import { ajv as defaultAjv } from '../ajv';
+import { NormalizedScenario } from '../scenario';
+import { uuid } from '../uuid';
+import { applyFn } from './fn';
+import { withHash } from './hash';
+import { instantiateState } from './instantiate';
+import { ActionEvent, Event, HashFn, InstantiateEvent, Process } from './interfaces/process';
+import {
+  findActionTransition,
+  findTimeoutTransition,
+  InstantiatedUpdateInstructions,
+  update,
+  validateStep,
+} from './step';
+import { isActionEvent, isInstantiateEvent, isTimeoutEvent } from './utils';
+import { validateProcess } from './validate';
+
+export function replay(input: Process | NormalizedScenario, events: Event[], options: { ajv?: Ajv } = {}): Process {
+  const isProcess = 'current' in input;
+
+  if (!isProcess && !isInstantiateEvent(events[0])) {
+    throw new Error('First event must be an instantiate event when replaying from genesis');
+  }
+
+  const process = isProcess
+    ? structuredClone(input as Process)
+    : replayInstantiate(input, events[0] as InstantiateEvent);
+
+  for (const event of isProcess ? events : events.slice(1)) {
+    if (isInstantiateEvent(event)) {
+      throw new Error('Cannot replay an instantiate event');
+    }
+
+    const previous = process.events[process.events.length - 1];
+
+    if (event.previous !== previous.hash) {
+      throw new Error(`Event ${event.hash} does not follow previous event ${previous.hash}`);
+    }
+
+    if (isActionEvent(event) && !event.skipped) {
+      replayAction(process, event, options);
+    }
+
+    if (isTimeoutEvent(event)) {
+      replayTimeout(process, event);
+    }
+  }
+
+  return process;
+}
+
+function replayInstantiate(scenario: NormalizedScenario & { id?: string }, event: InstantiateEvent): Process {
+  const scenarioId = scenario.id ?? uuid(scenario);
+
+  if (event.scenario !== scenarioId) {
+    throw new Error(`Event scenario id ${event.scenario} does not match scenario id ${scenarioId}`);
+  }
+
+  const process: Omit<Process, 'current'> = {
+    id: event.id,
+    title: scenario.title ?? `Process ${event.id}`,
+    tags: scenario.tags,
+    scenario: { id: scenarioId, ...scenario },
+    actors: event.actors,
+    vars: event.vars,
+    result: event.result,
+    events: [],
+  };
+
+  process.events.push(event);
+
+  const current = instantiateState(process, 'initial', event.timestamp);
+
+  return { ...process, current };
+}
+
+function replayAction(process: Process, event: ActionEvent, options: { ajv?: Ajv } = {}) {
+  const ajv = options.ajv ?? defaultAjv;
+
+  process.current.response = event.response;
+  process.current.actor = process.actors[event.actor.key];
+
+  process.events.push(event);
+
+  const stepErrors = validateStep(ajv, process, event.action, event.actor, event.response);
+  if (stepErrors.length > 0) {
+    throw new Error(`Event ${event.hash} is should have been skipped:\n${stepErrors.join('\n')}`);
+  }
+
+  const currentAction =
+    process.scenario.actions[`${process.current.key}.${event.action}`] || process.scenario.actions[event.action];
+
+  for (const scenarioInstructions of currentAction.update) {
+    const instructions: InstantiatedUpdateInstructions = applyFn(scenarioInstructions, process);
+    if (!instructions.if) continue;
+
+    update(process, instructions, event.actor.key, { ajv });
+  }
+
+  const updateErrors = validateProcess(process, { ajv });
+
+  const next = findActionTransition(process, event.action, event.actor.key);
+  if (!next) {
+    updateErrors.push(
+      `No transition found for action '${event.action}' in state '${process.current.key}' for actor ${event.actor.key}`,
+    );
+  }
+
+  if (updateErrors.length > 0) {
+    throw new Error(`Event ${event.hash} is should have been skipped:\n${updateErrors.join('\n')}`);
+  }
+
+  process.current = instantiateState(
+    process,
+    next!.goto ?? process.current.key,
+    next!.goto ? event.timestamp : process.current.timestamp,
+  );
+}
+
+function replayTimeout(process: Process, event: Event) {
+  const timePassed = event.timestamp.getTime() - process.events[process.events.length - 1].timestamp.getTime();
+
+  process.events.push(event);
+  const next = findTimeoutTransition(process, timePassed);
+
+  if (!next) {
+    throw new Error(`Timeout event ${event.hash} should not have been triggered`);
+  }
+
+  if (next.goto !== null) {
+    process.current = instantiateState(process, next.goto, event.timestamp);
+  }
+}
+
+export function migrate(
+  scenario: NormalizedScenario,
+  events: Event[],
+  options: { ajv?: Ajv; hashFn?: HashFn } = {},
+): Process {
+  if (!isInstantiateEvent(events[0])) {
+    throw new Error('First event must be an instantiate event when migrating');
+  }
+
+  const hashFn = options.hashFn ?? withHash;
+
+  events[0].scenario = scenario.id ?? uuid(scenario);
+  let previous = '';
+
+  const migrated = events.map((event) => {
+    if (!isInstantiateEvent(event)) {
+      event.previous = previous;
+    }
+
+    const migratedEvent = hashFn(event);
+    previous = migratedEvent.hash;
+
+    return migratedEvent;
+  });
+
+  return replay(scenario, migrated, options);
+}

--- a/src/process/utils.ts
+++ b/src/process/utils.ts
@@ -1,4 +1,4 @@
-import { Process } from './interfaces/process';
+import { ActionEvent, Event, InstantiateEvent, Process, TimeoutEvent } from './interfaces/process';
 
 export function hasEnded(process: Process): boolean {
   return !!process.current.key.match(/^\(.+\)$/);
@@ -10,4 +10,16 @@ export function chain<T extends Process>(process: T, ...fns: Array<(value: T) =>
 
 export function clean<T extends Record<any, any>>(obj: T): T {
   return Object.fromEntries(Object.entries(obj).filter(([_, value]) => value !== undefined)) as T;
+}
+
+export function isInstantiateEvent(event: Event): event is InstantiateEvent {
+  return 'scenario' in event;
+}
+
+export function isActionEvent(event: Event): event is ActionEvent {
+  return 'action' in event;
+}
+
+export function isTimeoutEvent(event: Event): event is TimeoutEvent {
+  return !('scenario' in event) && !('action' in event);
 }

--- a/src/scenario/validate.ts
+++ b/src/scenario/validate.ts
@@ -3,7 +3,7 @@ import { ErrorObject } from 'ajv/dist/types';
 import { ajv as defaultAjv } from '../ajv';
 import { isFn } from '../process/fn';
 import { scenarioSchema } from '../schemas/v1.0';
-import { EndState, Notify, Scenario, State } from './interfaces/scenario';
+import { EndState, Notify, Scenario, State, Transition } from './interfaces/scenario';
 
 export interface ValidateFunction {
   (data: any): boolean;
@@ -78,7 +78,7 @@ function validateTransitions(state: State, key: string, actions: string[], state
 
   const errors: ErrorObject[] = [];
 
-  Object.entries(state.transitions || {}).forEach(([index, transition]) => {
+  Object.entries(state.transitions || {}).forEach(([index, transition]: [string, Transition]) => {
     if (
       'goto' in transition &&
       transition.goto !== null &&

--- a/test/process/replay.spec.ts
+++ b/test/process/replay.spec.ts
@@ -1,0 +1,121 @@
+import { expect } from 'chai';
+import { chain, instantiate, step, TimeoutEvent, withHash } from '../../src/process';
+import { replay } from '../../src/process/replay';
+import { normalize } from '../../src/scenario';
+
+describe('replay', () => {
+  it('should replay a simple scenario', () => {
+    const scenario = normalize({
+      states: {
+        initial: {
+          on: 'next',
+          goto: 'second',
+        },
+        second: {
+          on: 'next',
+          goto: 'third',
+        },
+        third: {
+          on: 'next',
+          goto: '(done)',
+        },
+      },
+    });
+
+    const process = chain(
+      instantiate(scenario),
+      (process) => step(process, 'next'),
+      (process) => step(process, 'next'),
+    );
+
+    const result = replay(scenario, process.events);
+
+    expect(result.id).to.equal(process.id);
+    expect(result.current.key).to.equal('third');
+
+    expect(result.events).to.deep.equal(process.events);
+  });
+
+  it('should apply update instructions', () => {
+    const scenario = normalize({
+      actions: {
+        count: {
+          update: 'vars.count',
+        },
+      },
+      states: {
+        initial: {
+          on: 'count',
+          goto: '(done)',
+        },
+      },
+      vars: {
+        count: 'integer',
+      },
+    });
+
+    const process = step(instantiate(scenario), 'count', 'actor', 42);
+
+    const result = replay(scenario, process.events);
+
+    expect(result.current.key).to.equal('(done)');
+    expect(result.vars.count).to.equal(42);
+
+    expect(result.events).to.deep.equal(process.events);
+  });
+
+  it('should replay added events', () => {
+    const scenario = normalize({
+      states: {
+        initial: {
+          on: 'next',
+          goto: 'second',
+        },
+        second: {
+          on: 'next',
+          goto: 'third',
+        },
+        third: {
+          on: 'next',
+          goto: '(done)',
+        },
+      },
+    });
+
+    const process = step(instantiate(scenario), 'next');
+
+    const newEvents = chain(
+      process,
+      (process) => step(process, 'next'),
+      (process) => step(process, 'next'),
+    ).events.slice(process.events.length);
+
+    const result = replay(process, newEvents);
+
+    expect(result.id).to.equal(process.id);
+    expect(result.current.key).to.equal('(done)');
+  });
+
+  it('should replay a timeout event', () => {
+    const scenario = normalize({
+      states: {
+        initial: {
+          after: '3 minutes',
+          goto: '(done)',
+        },
+      },
+    });
+
+    const process = instantiate(scenario);
+
+    const event = withHash<TimeoutEvent>({
+      previous: process.events[0].hash,
+      timestamp: new Date(Date.now() + 5 * 60 * 1000),
+    });
+
+    const result = replay(process, [event]);
+
+    expect(result.id).to.equal(process.id);
+    expect(result.current.key).to.equal('(done)');
+  });
+});

--- a/test/process/step.spec.ts
+++ b/test/process/step.spec.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import { uuid } from '../../src';
-import { ActionEvent, chain, instantiate, step } from '../../src/process';
-import { hash } from '../../src/process/hash';
+import { ActionEvent, chain, hash, instantiate, step } from '../../src/process';
 import { normalize } from '../../src/scenario';
 
 describe('step', () => {


### PR DESCRIPTION
This pull request includes several changes to the `src/process` module, focusing on simplifying and improving the codebase, as well as adding new functionality for event handling and process replay. The most important changes include updates to the `InstantiateEvent` interface, modifications to the `timeout` function, and the addition of the `replay` function.

### Interface and Type Updates:
* [`src/process/interfaces/process.ts`](diffhunk://#diff-a2daf94dac921a51e5602105c8257b492a4d8161ef2daa219239b6c61002d547L14-R14): Updated the `InstantiateEvent` interface to use the full `Actor` type instead of omitting the `title` property.
* [`src/process/interfaces/process.ts`](diffhunk://#diff-a2daf94dac921a51e5602105c8257b492a4d8161ef2daa219239b6c61002d547L85-R85): Simplified the `HashFn` type by removing the default type parameter.

### Function Modifications:
* [`src/process/predict.ts`](diffhunk://#diff-5a4517614f75566b3b26948a1929d39a8076421eadda2e751c33e94ed94119adL50-R50): Modified the `tryToStep` function to use `Number.MAX_SAFE_INTEGER` for the `timePassed` option.
* [`src/process/step.ts`](diffhunk://#diff-0327e2acba0b4f821502f5a554640dbc3ef26a35d9e6983c3c4aa4d7afd3dbdcL193-R206): Updated the `timeout` function to use a `timePassed` option instead of a `force` option.

### New Functionality:
* [`src/process/replay.ts`](diffhunk://#diff-5810d9abf3f12b0923a43866818eef18c81a7db0f11b2e202b04b152f2526f51R1-R165): Added a new `replay` function to handle process replay from a given set of events.

### Utility Functions:
* [`src/process/utils.ts`](diffhunk://#diff-aa32b7cb90bbe178333b36e5bd1b799fdc57a598c6f85904c9e4cd1707b5c5b0R14-R25): Added utility functions `isInstantiateEvent`, `isActionEvent`, and `isTimeoutEvent` to differentiate between event types.

These changes improve the robustness and flexibility of the process handling and event replay mechanisms, making the codebase easier to maintain and extend.